### PR TITLE
CI: Cypress na pull requestech

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,5 @@
 name: cypress
-on: [ push ]
+on: [ push, pull_request ]
 jobs:
   cypress-run:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Přidán `pull_request` trigger do Cypress workflow, aby testy běžely i při PR.