### PR TITLE
Pouť a sjezd rodáků 2026: doplnění nedělní pohádky O Kokoketce

### DIFF
--- a/articles/Article20260417.tsx
+++ b/articles/Article20260417.tsx
@@ -52,6 +52,7 @@ export class Article20260417 extends Article {
                         <li><strong>13:00</strong> přivítání rodáků, beseda v kulturním domě</li>
                         <li>odpoledne volný program</li>
                         <li>křest fotoknihy Veselice</li>
+                        <li>pohádka nejen pro dospělé <em>O Kokoketce</em></li>
                         <li>k poslechu hraje kapela Frívajvl</li>
                     </ul>
                 </p>


### PR DESCRIPTION
## Summary
- Do nedělního programu pouti a IV. sjezdu rodáků 2026 doplněna položka „pohádka nejen pro dospělé *O Kokoketce*".

## Test plan
- [ ] Otevřít článek `/clanek/pout-a-sjezd-rodaku-2026/` a ověřit, že je nová položka v sekci „Neděle 14. 6. — Sjezd rodáků" pod křtem fotoknihy a před kapelou Frívajvl.
- [ ] Cypress: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)