### PR TITLE
Pouť a sjezd rodáků 2026: sobota od 13:00 + mše svatá u kapličky v 17:00

### DIFF
--- a/articles/Article20260417.tsx
+++ b/articles/Article20260417.tsx
@@ -39,9 +39,10 @@ export class Article20260417 extends Article {
                 <h3>Sobota 13. 6. — Pouť</h3>
                 <p>
                     <ul>
-                        <li><strong>12:00</strong> zahájení pouti, hry pro děti</li>
+                        <li><strong>13:00</strong> zahájení pouti, hry pro děti</li>
                         <li>pohádkoví Pat a Mat</li>
                         <li>loutkové divadlo <em>O kohoutkovi a slepičce</em></li>
+                        <li><strong>17:00</strong> mše svatá u kapličky</li>
                         <li><strong>21:00</strong> taneční zábava — k tanci hraje Trio Kent</li>
                     </ul>
                 </p>


### PR DESCRIPTION
Úprava sobotního programu pouti a IV. sjezdu rodáků ve Veselici (článek `Article20260417.tsx`):

- Zahájení pouti v sobotu posunuto z **12:00 na 13:00**.
- Přidána položka **17:00 mše svatá u kapličky**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)